### PR TITLE
Añade pruebas UI para listar álbumes

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -74,4 +74,6 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.runtime.livedata)
     implementation(libs.androidx.navigation.navigation.compose)
+    androidTestImplementation(libs.ui.test.junit4)
+    debugImplementation(libs.ui.test.manifest)
 }

--- a/app/src/androidTest/java/com/uniandes/vinilosapp/AlbumsScreenTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilosapp/AlbumsScreenTest.kt
@@ -1,0 +1,87 @@
+package com.uniandes.vinilosapp
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.rememberNavController
+import com.uniandes.vinilosapp.models.Album
+import com.uniandes.vinilosapp.views.album.AlbumRow
+import org.junit.Rule
+import org.junit.Test
+import androidx.compose.material3.*
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+class AlbumsScreenTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val albums = listOf(
+        Album(1, "Buscando América", "https://fakeimage.com/1", "1984-08-11", "Desc", "Salsa", "Elektra"),
+        Album(2, "Poeta del pueblo", "https://fakeimage.com/2", "1980-06-10", "Desc", "Salsa", "Elektra"),
+        Album(3, "A Night at the Opera", "https://fakeimage.com/3", "1975-11-21", "Desc", "Rock", "EMI"),
+        Album(4, "A Day at the Races", "https://fakeimage.com/4", "1976-12-10", "Desc", "Rock", "EMI")
+    )
+
+    @Test
+    fun albumBuscandoAmericaIsDisplayed() {
+        composeTestRule.setContent {
+            AlbumsScreenPreview(albums)
+        }
+
+        composeTestRule.onNodeWithText("Buscando América").assertIsDisplayed()
+    }
+
+    @Test
+    fun albumListDisplaysMinimumOf4Albums() {
+        composeTestRule.setContent {
+            AlbumsScreenPreview(albums)
+        }
+
+        composeTestRule.onAllNodesWithText("Ver").assertCountEquals(4)
+    }
+
+    @Test
+    fun eachAlbumRowShowsNameLabelAndButton() {
+        composeTestRule.setContent {
+            AlbumsScreenPreview(albums)
+        }
+
+        albums.forEach { album ->
+            composeTestRule.onNodeWithText(album.name).assertIsDisplayed()
+            composeTestRule.onAllNodesWithText(album.recordLabel).onFirst().assertIsDisplayed()
+        }
+        composeTestRule.onAllNodesWithText("Ver").assertCountEquals(4)
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlbumsScreenPreview(albums: List<Album>) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Álbumes") }
+            )
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp)
+        ) {
+            items(albums) { album ->
+                AlbumRow(
+                    album = album,
+                    onVerClick = {}
+                )
+                Divider()
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ lifecycleViewmodelCompose = "2.6.1"
 material = "1.12.0"
 materialIconsExtended = "1.4.3"
 navigationComposeVersion = "2.6.0"
+uiTestManifest = "1.5.1"
 volley = "1.2.1"
 constraintlayout = "2.1.4"
 lifecycleLivedataKtx = "2.8.7"
@@ -36,6 +37,8 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "uiTestManifest" }
+ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "uiTestManifest" }
 volley = { group = "com.android.volley", name = "volley", version.ref = "volley" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 androidx-lifecycle-livedata-ktx = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycleLivedataKtx" }


### PR DESCRIPTION
Se implementan 3 pruebas instrumentadas con Jetpack Compose:
- Verifica que se muestra el álbum "Buscando América"
- Verifica que se listan al menos 4 álbumes
- Verifica que cada álbum muestra nombre, sello discográfico y botón "Ver"