### PR TITLE
Añadir pruebas UI para detalle album

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     implementation(libs.androidx.material3)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.runtime.livedata)
+    implementation(libs.androidx.navigation.testing)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/androidTest/java/com/uniandes/vinilosapp/AlbumDetailTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilosapp/AlbumDetailTest.kt
@@ -1,0 +1,169 @@
+package com.uniandes.vinilosapp
+
+import androidx.compose.material3.*
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.uniandes.vinilosapp.models.AlbumDetails
+import com.uniandes.vinilosapp.models.Performer
+import com.uniandes.vinilosapp.models.Track
+import com.uniandes.vinilosapp.views.album.AlbumDetailContent
+import org.junit.Rule
+import org.junit.Test
+import androidx.compose.runtime.Composable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.testing.TestNavHostController
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.NavGraph
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import androidx.navigation.get
+import androidx.navigation.NavController
+import androidx.navigation.createGraph
+import androidx.navigation.NavigatorProvider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+
+fun createTestNavGraph(navController: TestNavHostController): NavGraph {
+    val navGraph = navController.createGraph(startDestination = "albumList") {
+        composable("albumList") {}
+        composable("albumDetail") {}
+    }
+    return navGraph
+}
+
+class AlbumDetailScreenTest {
+
+    // Álbum de prueba fijo (lo que devuelve normalmente el backend)
+    private val fakeAlbum = AlbumDetails(
+        albumId = 1,
+        name = "Buscando América",
+        cover = "https://fakeimage.com/cover",
+        releaseDate = "01 de agosto de 1984",
+        description = "Buscando América es el primer álbum de Rubén Blades y Seis del Solar lanzado en 1984.",
+        genre = "Salsa",
+        recordLabel = "Elektra",
+        performers = listOf(
+            Performer(
+                performerID = 1,
+                name = "Rubén Blades Bellido de Luna",
+                image = "https://fakeimage.com/ruben",
+                description = "Cantante panameño de salsa y política"
+            )
+        ),
+        tracks = listOf(
+            Track(trackId = 1, name = "Decisiones", duration = "5:05"),
+            Track(trackId = 2, name = "Desapariciones", duration = "6:29")
+        )
+    )
+
+    @Test
+    fun albumTitleIsDisplayed() {
+        composeTestRule.setContent {
+            AlbumDetailScreenPreview(fakeAlbum)
+        }
+
+        composeTestRule.onNodeWithText("Buscando América").assertIsDisplayed()
+    }
+
+    @Test
+    fun albumDescriptionIsDisplayed() {
+        composeTestRule.setContent {
+            AlbumDetailScreenPreview(fakeAlbum)
+        }
+
+        composeTestRule.onNodeWithText("Buscando América es el primer álbum", substring = true)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun albumTracksAreDisplayed() {
+        composeTestRule.setContent {
+            AlbumDetailScreenPreview(fakeAlbum)
+        }
+
+        composeTestRule.onNodeWithText("Decisiones")
+            .performScrollTo()
+            .assertIsDisplayed()
+
+        composeTestRule.onNodeWithText("Desapariciones")
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun goBackButtonTriggersNavigation() {
+        val navController = TestNavHostController(composeTestRule.activity)
+
+        composeTestRule.setContent {
+            navController.navigatorProvider.addNavigator(
+                androidx.navigation.compose.ComposeNavigator()
+            )
+
+            val graph = navController.createGraph(startDestination = "albumList") {
+                composable("albumList") {}
+                composable("albumDetail") {}
+            }
+            navController.graph = graph
+
+            navController.navigate("albumDetail")
+
+            AlbumDetailNavTestScreen(fakeAlbum, navController)
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Go back")
+            .performClick()
+
+        composeTestRule.waitForIdle()
+        assert(navController.currentDestination?.route == "albumList")
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlbumDetailScreenPreview(album: AlbumDetails) {
+    Scaffold(
+        topBar = {
+            TopAppBar(title = { Text(album.name) })
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            AlbumDetailContent(album)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AlbumDetailNavTestScreen(album: AlbumDetails, navController: NavController) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(album.name) },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                            contentDescription = "Go back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
+            AlbumDetailContent(album)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ activityCompose = "1.10.1"
 composeBom = "2024.09.00"
 activity = "1.10.1"
 runtimeLivedata = "1.7.8"
+navigationTesting = "2.8.9"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -57,6 +58,7 @@ androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "runtimeLivedata" }
+androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationTesting" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Pruebas Historia 2: Ver detalle de álbum

- Verifica que se muestra el título del álbum  
- Verifica que se muestra la descripción  
- Verifica que se muestran las canciones asociadas  
- Verifica que al presionar el botón de regreso (flecha), se navega correctamente al listado de álbumes

Se creó el archivo de prueba:
- `AlbumDetailTest.kt`