### PR TITLE
feat: create album

### DIFF
--- a/app/src/main/java/com/uniandes/vinilosapp/database/AlbumDAO.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/database/AlbumDAO.kt
@@ -1,6 +1,5 @@
 package com.uniandes.vinilosapp.database
 
-
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
@@ -9,12 +8,11 @@ import com.uniandes.vinilosapp.models.Album
 
 @Dao
 interface AlbumDao {
-    @Query("SELECT * FROM tb_albums")
-    fun getAlbums():List<Album>
+    @Query("SELECT * FROM tb_albums") fun getAlbums(): List<Album>
 
-    @Query("SELECT * FROM tb_albums WHERE albumId = :idalbum")
-    fun getAlbum(idalbum:Int): Album
+    @Query("SELECT * FROM tb_albums WHERE albumId = :idalbum") fun getAlbum(idalbum: Int): Album
 
-    @Insert(onConflict = OnConflictStrategy.IGNORE)
-    fun insert(album: Album)
+    @Insert(onConflict = OnConflictStrategy.IGNORE) fun insert(album: Album)
+
+    @Query("DELETE FROM tb_albums") suspend fun clearAll()
 }

--- a/app/src/main/java/com/uniandes/vinilosapp/database/Converters.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/database/Converters.kt
@@ -1,0 +1,22 @@
+package com.uniandes.vinilosapp.database
+
+import androidx.room.TypeConverter
+import com.uniandes.vinilosapp.models.GENRE
+import com.uniandes.vinilosapp.models.RECORD_LABEL
+
+/**
+ * Type converters for Room database to handle enum types
+ */
+class Converters {
+    @TypeConverter
+    fun fromGenre(value: GENRE): String = value.toString()
+    
+    @TypeConverter
+    fun toGenre(value: String): GENRE = GENRE.fromString(value)
+    
+    @TypeConverter
+    fun fromRecordLabel(value: RECORD_LABEL): String = value.toString()
+    
+    @TypeConverter
+    fun toRecordLabel(value: String): RECORD_LABEL = RECORD_LABEL.fromString(value)
+}

--- a/app/src/main/java/com/uniandes/vinilosapp/database/Converters.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/database/Converters.kt
@@ -4,19 +4,13 @@ import androidx.room.TypeConverter
 import com.uniandes.vinilosapp.models.GENRE
 import com.uniandes.vinilosapp.models.RECORD_LABEL
 
-/**
- * Type converters for Room database to handle enum types
- */
+/** Type converters for Room database to handle enum types */
 class Converters {
-    @TypeConverter
-    fun fromGenre(value: GENRE): String = value.toString()
-    
-    @TypeConverter
-    fun toGenre(value: String): GENRE = GENRE.fromString(value)
-    
-    @TypeConverter
-    fun fromRecordLabel(value: RECORD_LABEL): String = value.toString()
-    
-    @TypeConverter
-    fun toRecordLabel(value: String): RECORD_LABEL = RECORD_LABEL.fromString(value)
+    @TypeConverter fun fromGenre(value: GENRE): String = value.toString()
+
+    @TypeConverter fun toGenre(value: String): GENRE = GENRE.fromString(value)
+
+    @TypeConverter fun fromRecordLabel(value: RECORD_LABEL): String = value.toString()
+
+    @TypeConverter fun toRecordLabel(value: String): RECORD_LABEL = RECORD_LABEL.fromString(value)
 }

--- a/app/src/main/java/com/uniandes/vinilosapp/database/VinilosDatabase.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/database/VinilosDatabase.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
 import com.uniandes.vinilosapp.models.Album
 import com.uniandes.vinilosapp.models.Collector
 import com.uniandes.vinilosapp.models.Performer
 
 
-@Database(entities = [Album::class, Performer::class, Collector::class], version = 2, exportSchema = false)
+@Database(entities = [Album::class, Performer::class, Collector::class], version = 3, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class VinilosDatabase : RoomDatabase() {
     abstract fun albumsDao(): AlbumDao
     abstract fun performerDao(): PerformerDao

--- a/app/src/main/java/com/uniandes/vinilosapp/models/Album.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/models/Album.kt
@@ -3,6 +3,65 @@ package com.uniandes.vinilosapp.models
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
+enum class GENRE {
+    CLASSICAL, 
+    SALSA, 
+    ROCK, 
+    FOLK;
+    
+    override fun toString(): String {
+        return when(this) {
+            CLASSICAL -> "Classical"
+            SALSA -> "Salsa"
+            ROCK -> "Rock"
+            FOLK -> "Folk"
+        }
+    }
+    
+    companion object {
+        fun fromString(value: String): GENRE {
+            return when(value) {
+                "Classical" -> CLASSICAL
+                "Salsa" -> SALSA
+                "Rock" -> ROCK
+                "Folk" -> FOLK
+                else -> throw IllegalArgumentException("Unknown genre: $value")
+            }
+        }
+    }
+}
+
+enum class RECORD_LABEL {
+    SONY, 
+    EMI, 
+    FUENTES, 
+    ELEKTRA, 
+    FANIA;
+    
+    override fun toString(): String {
+        return when(this) {
+            SONY -> "Sony Music"
+            EMI -> "EMI"
+            FUENTES -> "Discos Fuentes"
+            ELEKTRA -> "Elektra"
+            FANIA -> "Fania Records"
+        }
+    }
+    
+    companion object {
+        fun fromString(value: String): RECORD_LABEL {
+            return when(value) {
+                "Sony Music" -> SONY
+                "EMI" -> EMI
+                "Discos Fuentes" -> FUENTES
+                "Elektra" -> ELEKTRA
+                "Fania Records" -> FANIA
+                else -> throw IllegalArgumentException("Unknown record label: $value")
+            }
+        }
+    }
+}
+
 @Entity(tableName = "tb_albums")
 data class Album (
     @PrimaryKey val albumId:Int,
@@ -10,6 +69,6 @@ data class Album (
     val cover:String,
     val releaseDate:String,
     val description:String,
-    val genre:String,
-    val recordLabel:String,
+    val genre: GENRE,
+    val recordLabel: RECORD_LABEL,
 )

--- a/app/src/main/java/com/uniandes/vinilosapp/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/network/NetworkServiceAdapter.kt
@@ -11,13 +11,16 @@ import com.uniandes.vinilosapp.models.Album
 import com.uniandes.vinilosapp.models.AlbumDetails
 import com.uniandes.vinilosapp.models.Band
 import com.uniandes.vinilosapp.models.Collector
+import com.uniandes.vinilosapp.models.GENRE
 import com.uniandes.vinilosapp.models.Musician
 import com.uniandes.vinilosapp.models.Performer
+import com.uniandes.vinilosapp.models.RECORD_LABEL
 import com.uniandes.vinilosapp.models.Track
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 import org.json.JSONArray
 import org.json.JSONObject
+import kotlin.coroutines.resumeWithException
 
 class NetworkServiceAdapter constructor(context: Context) {
         companion object {
@@ -48,30 +51,12 @@ class NetworkServiceAdapter constructor(context: Context) {
                                                         val album =
                                                                 Album(
                                                                         albumId = item.getInt("id"),
-                                                                        name =
-                                                                                item.getString(
-                                                                                        "name"
-                                                                                ),
-                                                                        cover =
-                                                                                item.getString(
-                                                                                        "cover"
-                                                                                ),
-                                                                        recordLabel =
-                                                                                item.getString(
-                                                                                        "recordLabel"
-                                                                                ),
-                                                                        releaseDate =
-                                                                                item.getString(
-                                                                                        "releaseDate"
-                                                                                ),
-                                                                        genre =
-                                                                                item.getString(
-                                                                                        "genre"
-                                                                                ),
-                                                                        description =
-                                                                                item.getString(
-                                                                                        "description"
-                                                                                )
+                                                                        name = item.getString("name"),
+                                                                        cover = item.getString("cover"),
+                                                                        recordLabel = RECORD_LABEL.fromString(item.getString("recordLabel")),
+                                                                        releaseDate = item.getString("releaseDate"),
+                                                                        genre = GENRE.fromString(item.getString("genre")),
+                                                                        description = item.getString("description")
                                                                 )
                                                         list.add(i, album)
                                                 }
@@ -407,6 +392,40 @@ class NetworkServiceAdapter constructor(context: Context) {
                                                 cont.resume(band)
                                         },
                                         { throw it }
+                                )
+                        )
+                }
+
+        suspend fun createAlbum(album: Album) =
+                suspendCoroutine<Album> { cont ->
+                        val body = JSONObject().apply {
+                                put("name", album.name)
+                                put("cover", album.cover)
+                                put("releaseDate", album.releaseDate)
+                                put("description", album.description)
+                                put("genre", album.genre.toString())
+                                put("recordLabel", album.recordLabel.toString())
+                        }
+                        
+                        requestQueue.add(
+                                postRequest(
+                                        "albums",
+                                        body,
+                                        { response ->
+                                                val album = Album(
+                                                        albumId = response.getInt("id"),
+                                                        name = response.getString("name"),
+                                                        cover = response.getString("cover"),
+                                                        recordLabel = RECORD_LABEL.fromString(response.getString("recordLabel")),
+                                                        releaseDate = response.getString("releaseDate"),
+                                                        genre = GENRE.fromString(response.getString("genre")),
+                                                        description = response.getString("description")
+                                                )
+                                                cont.resume(album)
+                                        },
+                                        { error -> 
+                                                cont.resumeWithException(error)
+                                        }
                                 )
                         )
                 }

--- a/app/src/main/java/com/uniandes/vinilosapp/repositories/AlbumRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/repositories/AlbumRepository.kt
@@ -3,39 +3,51 @@ package com.uniandes.vinilosapp.repositories
 import android.app.Application
 import android.content.Context
 import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import com.uniandes.vinilosapp.database.AlbumDao
 import com.uniandes.vinilosapp.models.Album
 import com.uniandes.vinilosapp.models.AlbumDetails
-import com.uniandes.vinilosapp.models.GENRE
-import com.uniandes.vinilosapp.models.RECORD_LABEL
 import com.uniandes.vinilosapp.network.NetworkServiceAdapter
 
-class AlbumRepository (val application: Application,  private val albumDao: AlbumDao){
-
+class AlbumRepository(val application: Application, private val albumDao: AlbumDao) {
 
     suspend fun getAlbums(): List<Album> {
         var cached = albumDao.getAlbums()
         return if (cached.isNullOrEmpty()) {
             val cm =
-                application.baseContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            if (cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_WIFI && cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_MOBILE) {
+                    application.baseContext.getSystemService(Context.CONNECTIVITY_SERVICE) as
+                            ConnectivityManager
+            if (cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_WIFI &&
+                            cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_MOBILE
+            ) {
                 emptyList()
             } else NetworkServiceAdapter.getInstance(application).getAlbums()
         } else cached
     }
 
-    suspend fun getAlbum(albumId:Int): AlbumDetails {
+    suspend fun getAlbum(albumId: Int): AlbumDetails {
         return NetworkServiceAdapter.getInstance(application).getAlbum(albumId)
     }
 
     suspend fun createAlbum(album: Album): Album {
-        val cm = application.baseContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-        
-        if (cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_WIFI && 
-            cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_MOBILE) {
+        val cm =
+                application.baseContext.getSystemService(Context.CONNECTIVITY_SERVICE) as
+                        ConnectivityManager
+
+        val activeNetwork = cm.activeNetwork
+        val capabilities = cm.getNetworkCapabilities(activeNetwork)
+        val isConnected =
+                capabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+
+        if (!isConnected) {
             throw Exception("No internet connection available")
         }
-        
-        return NetworkServiceAdapter.getInstance(application).createAlbum(album)
+
+        val createdAlbum = NetworkServiceAdapter.getInstance(application).createAlbum(album)
+
+        // Clear the local cache so that the next getAlbums call will fetch from backend
+        albumDao.clearAll()
+
+        return createdAlbum
     }
 }

--- a/app/src/main/java/com/uniandes/vinilosapp/repositories/AlbumRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/repositories/AlbumRepository.kt
@@ -6,6 +6,8 @@ import android.net.ConnectivityManager
 import com.uniandes.vinilosapp.database.AlbumDao
 import com.uniandes.vinilosapp.models.Album
 import com.uniandes.vinilosapp.models.AlbumDetails
+import com.uniandes.vinilosapp.models.GENRE
+import com.uniandes.vinilosapp.models.RECORD_LABEL
 import com.uniandes.vinilosapp.network.NetworkServiceAdapter
 
 class AlbumRepository (val application: Application,  private val albumDao: AlbumDao){
@@ -26,6 +28,14 @@ class AlbumRepository (val application: Application,  private val albumDao: Albu
         return NetworkServiceAdapter.getInstance(application).getAlbum(albumId)
     }
 
-
-
+    suspend fun createAlbum(album: Album): Album {
+        val cm = application.baseContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        
+        if (cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_WIFI && 
+            cm.activeNetworkInfo?.type != ConnectivityManager.TYPE_MOBILE) {
+            throw Exception("No internet connection available")
+        }
+        
+        return NetworkServiceAdapter.getInstance(application).createAlbum(album)
+    }
 }

--- a/app/src/main/java/com/uniandes/vinilosapp/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/viewmodels/AlbumViewModel.kt
@@ -9,16 +9,19 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.uniandes.vinilosapp.database.VinilosDatabase
 import com.uniandes.vinilosapp.models.Album
-import com.uniandes.vinilosapp.network.NetworkServiceAdapter
 import com.uniandes.vinilosapp.repositories.AlbumRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-class AlbumViewModel(application: Application) :  AndroidViewModel(application) {
+class AlbumViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _albums = MutableLiveData<List<Album>>()
-    private val albumsRepository = AlbumRepository(application, VinilosDatabase.getDatabase(application.applicationContext).albumsDao())
+    private val albumsRepository =
+            AlbumRepository(
+                    application,
+                    VinilosDatabase.getDatabase(application.applicationContext).albumsDao()
+            )
 
     val albums: LiveData<List<Album>>
         get() = _albums
@@ -37,18 +40,22 @@ class AlbumViewModel(application: Application) :  AndroidViewModel(application) 
         refreshData()
     }
 
+    // Public method to manually refresh albums list
+    fun refreshAlbums() {
+        refreshData()
+    }
+
     private fun refreshData() {
         try {
-            viewModelScope.launch(Dispatchers.Default){
-                withContext(Dispatchers.IO){
+            viewModelScope.launch(Dispatchers.Default) {
+                withContext(Dispatchers.IO) {
                     var data = albumsRepository.getAlbums()
                     _albums.postValue(data)
                 }
                 _eventNetworkError.postValue(false)
                 _isNetworkErrorShown.postValue(false)
             }
-        }
-        catch (e:Exception){
+        } catch (e: Exception) {
             _eventNetworkError.value = true
         }
     }
@@ -59,13 +66,9 @@ class AlbumViewModel(application: Application) :  AndroidViewModel(application) 
     class Factory(val app: Application) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             if (modelClass.isAssignableFrom(AlbumViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return AlbumViewModel(app) as T
+                @Suppress("UNCHECKED_CAST") return AlbumViewModel(app) as T
             }
             throw IllegalArgumentException("Unable to construct viewmodel")
         }
     }
-
-
-
 }

--- a/app/src/main/java/com/uniandes/vinilosapp/viewmodels/AlbumViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/viewmodels/AlbumViewModel.kt
@@ -36,6 +36,12 @@ class AlbumViewModel(application: Application) : AndroidViewModel(application) {
     val isNetworkErrorShown: LiveData<Boolean>
         get() = _isNetworkErrorShown
 
+    // Add loading state
+    private var _isLoading = MutableLiveData<Boolean>(false)
+
+    val isLoading: LiveData<Boolean>
+        get() = _isLoading
+
     init {
         refreshData()
     }
@@ -47,6 +53,7 @@ class AlbumViewModel(application: Application) : AndroidViewModel(application) {
 
     private fun refreshData() {
         try {
+            _isLoading.value = true
             viewModelScope.launch(Dispatchers.Default) {
                 withContext(Dispatchers.IO) {
                     var data = albumsRepository.getAlbums()
@@ -54,9 +61,11 @@ class AlbumViewModel(application: Application) : AndroidViewModel(application) {
                 }
                 _eventNetworkError.postValue(false)
                 _isNetworkErrorShown.postValue(false)
+                _isLoading.postValue(false)
             }
         } catch (e: Exception) {
             _eventNetworkError.value = true
+            _isLoading.value = false
         }
     }
 

--- a/app/src/main/java/com/uniandes/vinilosapp/viewmodels/CreateAlbumViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/viewmodels/CreateAlbumViewModel.kt
@@ -1,0 +1,405 @@
+package com.uniandes.vinilosapp.viewmodels
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.uniandes.vinilosapp.database.VinilosDatabase
+import com.uniandes.vinilosapp.models.Album
+import com.uniandes.vinilosapp.models.GENRE
+import com.uniandes.vinilosapp.models.RECORD_LABEL
+import com.uniandes.vinilosapp.repositories.AlbumRepository
+import java.net.MalformedURLException
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class CreateAlbumViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val albumsRepository =
+            AlbumRepository(
+                    application,
+                    VinilosDatabase.getDatabase(application.applicationContext).albumsDao()
+            )
+
+    private val _isLoading = MutableLiveData<Boolean>(false)
+    val isLoading: LiveData<Boolean>
+        get() = _isLoading
+
+    private val _error = MutableLiveData<String?>(null)
+    val error: LiveData<String?>
+        get() = _error
+
+    private val _createSuccess = MutableLiveData<Boolean>(false)
+    val createSuccess: LiveData<Boolean>
+        get() = _createSuccess
+
+    // Field touch states - track if user has interacted with the field
+    private val _nameTouched = MutableLiveData<Boolean>(false)
+    val nameTouched: LiveData<Boolean>
+        get() = _nameTouched
+
+    private val _descriptionTouched = MutableLiveData<Boolean>(false)
+    val descriptionTouched: LiveData<Boolean>
+        get() = _descriptionTouched
+
+    private val _coverUrlTouched = MutableLiveData<Boolean>(false)
+    val coverUrlTouched: LiveData<Boolean>
+        get() = _coverUrlTouched
+
+    private val _genreTouched = MutableLiveData<Boolean>(false)
+    val genreTouched: LiveData<Boolean>
+        get() = _genreTouched
+
+    private val _recordLabelTouched = MutableLiveData<Boolean>(false)
+    val recordLabelTouched: LiveData<Boolean>
+        get() = _recordLabelTouched
+
+    private val _releaseDateTouched = MutableLiveData<Boolean>(false)
+    val releaseDateTouched: LiveData<Boolean>
+        get() = _releaseDateTouched
+
+    // Validation states
+    private val _nameError = MutableLiveData<String?>(null)
+    val nameError: LiveData<String?>
+        get() = _nameError
+
+    private val _descriptionError = MutableLiveData<String?>(null)
+    val descriptionError: LiveData<String?>
+        get() = _descriptionError
+
+    private val _coverUrlError = MutableLiveData<String?>(null)
+    val coverUrlError: LiveData<String?>
+        get() = _coverUrlError
+
+    private val _genreError = MutableLiveData<String?>(null)
+    val genreError: LiveData<String?>
+        get() = _genreError
+
+    private val _recordLabelError = MutableLiveData<String?>(null)
+    val recordLabelError: LiveData<String?>
+        get() = _recordLabelError
+
+    private val _releaseDateError = MutableLiveData<String?>(null)
+    val releaseDateError: LiveData<String?>
+        get() = _releaseDateError
+
+    private val _isFormValid = MutableLiveData<Boolean>(false)
+    val isFormValid: LiveData<Boolean>
+        get() = _isFormValid
+
+    private val _isValidUrl = MutableLiveData<Boolean>(false)
+    val isValidUrl: LiveData<Boolean>
+        get() = _isValidUrl
+
+    // Form fields
+    private val _name = MutableLiveData<String>("")
+    val name: LiveData<String>
+        get() = _name
+
+    private val _description = MutableLiveData<String>("")
+    val description: LiveData<String>
+        get() = _description
+
+    private val _coverUrl = MutableLiveData<String>("")
+    val coverUrl: LiveData<String>
+        get() = _coverUrl
+
+    private val _genre = MutableLiveData<GENRE?>(null)
+    val genre: LiveData<GENRE?>
+        get() = _genre
+
+    private val _recordLabel = MutableLiveData<RECORD_LABEL?>(null)
+    val recordLabel: LiveData<RECORD_LABEL?>
+        get() = _recordLabel
+
+    private val _releaseDate = MutableLiveData<Date?>(null)
+    val releaseDate: LiveData<Date?>
+        get() = _releaseDate
+
+    // Formatted display date for UI
+    private val _releaseDateFormatted = MutableLiveData<String>("Seleccionar fecha")
+    val releaseDateFormatted: LiveData<String>
+        get() = _releaseDateFormatted
+
+    // Functions to update form fields with validation
+    fun updateName(value: String) {
+        _name.value = value
+        if (!_nameTouched.value!!) {
+            _nameTouched.value = true
+        }
+        validateName(value)
+        validateForm()
+    }
+
+    fun updateDescription(value: String) {
+        _description.value = value
+        if (!_descriptionTouched.value!!) {
+            _descriptionTouched.value = true
+        }
+        validateDescription(value)
+        validateForm()
+    }
+
+    fun updateCoverUrl(value: String) {
+        _coverUrl.value = value
+        if (!_coverUrlTouched.value!!) {
+            _coverUrlTouched.value = true
+        }
+        val urlIsValid = isValidUrl(value)
+        _isValidUrl.value = urlIsValid
+        validateCoverUrl(value, urlIsValid)
+        validateForm()
+    }
+
+    fun updateGenre(value: GENRE?) {
+        _genre.value = value
+        if (!_genreTouched.value!!) {
+            _genreTouched.value = true
+        }
+        validateGenre(value)
+        validateForm()
+    }
+
+    fun updateRecordLabel(value: RECORD_LABEL?) {
+        _recordLabel.value = value
+        if (!_recordLabelTouched.value!!) {
+            _recordLabelTouched.value = true
+        }
+        validateRecordLabel(value)
+        validateForm()
+    }
+
+    fun updateReleaseDate(date: Date?) {
+        _releaseDate.value = date
+        if (!_releaseDateTouched.value!!) {
+            _releaseDateTouched.value = true
+        }
+
+        if (date != null) {
+            // Format for display
+            val displayFormat = SimpleDateFormat("dd 'de' MMMM 'de' yyyy", Locale("es", "ES"))
+            _releaseDateFormatted.value = displayFormat.format(date)
+        } else {
+            _releaseDateFormatted.value = "Seleccionar fecha"
+        }
+
+        validateReleaseDate(date)
+        validateForm()
+    }
+
+    // Functions to mark fields as touched
+    fun onNameTouched() {
+        if (!_nameTouched.value!!) {
+            _nameTouched.value = true
+            validateName(_name.value)
+            validateForm()
+        }
+    }
+
+    fun onDescriptionTouched() {
+        if (!_descriptionTouched.value!!) {
+            _descriptionTouched.value = true
+            validateDescription(_description.value)
+            validateForm()
+        }
+    }
+
+    fun onCoverUrlTouched() {
+        if (!_coverUrlTouched.value!!) {
+            _coverUrlTouched.value = true
+            validateCoverUrl(_coverUrl.value, isValidUrl(_coverUrl.value!!))
+            validateForm()
+        }
+    }
+
+    fun onGenreTouched() {
+        if (!_genreTouched.value!!) {
+            _genreTouched.value = true
+            validateGenre(_genre.value)
+            validateForm()
+        }
+    }
+
+    fun onRecordLabelTouched() {
+        if (!_recordLabelTouched.value!!) {
+            _recordLabelTouched.value = true
+            validateRecordLabel(_recordLabel.value)
+            validateForm()
+        }
+    }
+
+    fun onReleaseDateTouched() {
+        if (!_releaseDateTouched.value!!) {
+            _releaseDateTouched.value = true
+            validateReleaseDate(_releaseDate.value)
+            validateForm()
+        }
+    }
+
+    // Function to check if a string is a valid URL
+    private fun isValidUrl(url: String?): Boolean {
+        return try {
+            if (url.isNullOrBlank()) return false
+            URL(url)
+            true
+        } catch (e: MalformedURLException) {
+            false
+        }
+    }
+
+    private fun validateName(value: String?) {
+        _nameError.value =
+                if (value.isNullOrBlank()) {
+                    "El nombre del álbum es obligatorio"
+                } else {
+                    null
+                }
+    }
+
+    private fun validateDescription(value: String?) {
+        _descriptionError.value =
+                if (value.isNullOrBlank()) {
+                    "La descripción es obligatoria"
+                } else {
+                    null
+                }
+    }
+
+    private fun validateCoverUrl(value: String?, isValid: Boolean) {
+        _coverUrlError.value =
+                when {
+                    value.isNullOrBlank() -> "La URL de portada es obligatoria"
+                    !isValid -> "La URL ingresada no es válida"
+                    else -> null
+                }
+    }
+
+    private fun validateGenre(value: GENRE?) {
+        _genreError.value =
+                if (value == null) {
+                    "Debes seleccionar un género"
+                } else {
+                    null
+                }
+    }
+
+    private fun validateRecordLabel(value: RECORD_LABEL?) {
+        _recordLabelError.value =
+                if (value == null) {
+                    "Debes seleccionar una disquera"
+                } else {
+                    null
+                }
+    }
+
+    private fun validateReleaseDate(date: Date?) {
+        _releaseDateError.value =
+                when {
+                    date == null -> "La fecha de lanzamiento es obligatoria"
+                    isDateInFuture(date) -> "La fecha de lanzamiento no puede ser futura"
+                    else -> null
+                }
+    }
+
+    private fun isDateInFuture(date: Date): Boolean {
+        val today =
+                Calendar.getInstance()
+                        .apply {
+                            set(Calendar.HOUR_OF_DAY, 0)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0)
+                            set(Calendar.MILLISECOND, 0)
+                        }
+                        .time
+
+        return date.after(today)
+    }
+
+    private fun validateForm() {
+        // Check if all required fields are filled and valid
+        val nameValid = _nameError.value == null && !_name.value.isNullOrBlank()
+        val descriptionValid =
+                _descriptionError.value == null && !_description.value.isNullOrBlank()
+        val coverUrlValid = _coverUrlError.value == null && !_coverUrl.value.isNullOrBlank()
+        val genreValid = _genreError.value == null && _genre.value != null
+        val recordLabelValid = _recordLabelError.value == null && _recordLabel.value != null
+        val releaseDateValid = _releaseDateError.value == null && _releaseDate.value != null
+
+        _isFormValid.value =
+                nameValid &&
+                        descriptionValid &&
+                        coverUrlValid &&
+                        genreValid &&
+                        recordLabelValid &&
+                        releaseDateValid
+    }
+
+    fun createAlbum() {
+        if (_isFormValid.value != true) return
+
+        _isLoading.value = true
+        _error.value = null
+
+        viewModelScope.launch {
+            try {
+                // Create a placeholder album ID (will be replaced by the server)
+                val tempAlbumId = 0
+
+                // Format the release date
+                val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+                val releaseDate = sdf.format(_releaseDate.value!!)
+
+                val album =
+                        Album(
+                                albumId = tempAlbumId,
+                                name = _name.value!!,
+                                cover = _coverUrl.value!!,
+                                releaseDate = releaseDate,
+                                description = _description.value!!,
+                                genre = _genre.value!!,
+                                recordLabel = _recordLabel.value!!
+                        )
+
+                withContext(Dispatchers.IO) { albumsRepository.createAlbum(album) }
+                _createSuccess.value = true
+            } catch (e: Exception) {
+                _error.value = e.message ?: "Error creating album"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun resetState() {
+        _createSuccess.value = false
+        _error.value = null
+    }
+
+    init {
+        // Initialize touch states to false
+        _nameTouched.value = false
+        _descriptionTouched.value = false
+        _coverUrlTouched.value = false
+        _genreTouched.value = false
+        _recordLabelTouched.value = false
+        _releaseDateTouched.value = false
+    }
+
+    class Factory(val app: Application) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            if (modelClass.isAssignableFrom(CreateAlbumViewModel::class.java)) {
+                @Suppress("UNCHECKED_CAST") return CreateAlbumViewModel(app) as T
+            }
+            throw IllegalArgumentException("Unable to construct viewmodel")
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumRow.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumRow.kt
@@ -30,7 +30,7 @@ fun AlbumRow(album: Album, onVerClick: () -> Unit) {
         )
         Column(modifier = Modifier.weight(1f)) {
             Text(text = album.name, style = MaterialTheme.typography.titleMedium)
-            Text(text = album.recordLabel, style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onBackground)
+            Text(text = album.recordLabel.toString(), style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onBackground)
         }
         Button(onClick = onVerClick, colors=ButtonDefaults.buttonColors(
             containerColor = Color.Black)) {

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.AddCircle
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -30,6 +31,22 @@ fun AlbumsScreen(navController: NavController) {
     val albumViewModel: AlbumViewModel = viewModel(factory = AlbumViewModel.Factory(application))
 
     val albums by albumViewModel.albums.observeAsState(initial = emptyList())
+
+    // Check if we need to refresh albums when navigating back from CreateAlbumScreen
+    LaunchedEffect(Unit) {
+        // Get the refresh flag from the SavedStateHandle
+        val needsRefresh =
+                navController.currentBackStackEntry?.savedStateHandle?.get<Boolean>(
+                        "refresh_albums"
+                )
+                        ?: false
+
+        // If the flag is set, refresh albums and reset the flag
+        if (needsRefresh) {
+            albumViewModel.refreshAlbums()
+            navController.currentBackStackEntry?.savedStateHandle?.set("refresh_albums", false)
+        }
+    }
 
     Scaffold(
             topBar = {

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
@@ -1,6 +1,7 @@
 package com.uniandes.vinilosapp.views.album
 
 import android.app.Application
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
@@ -31,6 +33,7 @@ fun AlbumsScreen(navController: NavController) {
     val albumViewModel: AlbumViewModel = viewModel(factory = AlbumViewModel.Factory(application))
 
     val albums by albumViewModel.albums.observeAsState(initial = emptyList())
+    val isLoading = albumViewModel.isLoading.observeAsState(initial = false)
 
     // Check if we need to refresh albums when navigating back from CreateAlbumScreen
     LaunchedEffect(Unit) {
@@ -65,15 +68,25 @@ fun AlbumsScreen(navController: NavController) {
                 )
             }
     ) { innerPadding ->
-        LazyColumn(
-                modifier = Modifier.fillMaxSize().padding(innerPadding).padding(horizontal = 16.dp)
+        Box(
+                modifier = Modifier.fillMaxSize().padding(innerPadding),
+                contentAlignment = Alignment.Center
         ) {
-            items(albums) { album ->
-                AlbumRow(
-                        album = album,
-                        onVerClick = { navController.navigate("albumes/${album.albumId}") }
+            if (isLoading.value) {
+                CircularProgressIndicator(
+                        modifier = Modifier.size(32.dp),
+                        color = MaterialTheme.colorScheme.secondary
                 )
-                Divider()
+            } else {
+                LazyColumn(modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp)) {
+                    items(albums) { album ->
+                        AlbumRow(
+                                album = album,
+                                onVerClick = { navController.navigate("albumes/${album.albumId}") }
+                        )
+                        HorizontalDivider()
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/AlbumScreen.kt
@@ -36,11 +36,7 @@ fun AlbumsScreen(navController: NavController) {
                 TopAppBar(
                         title = { Text("Álbumes", fontWeight = FontWeight.Bold) },
                         actions = {
-                            IconButton(
-                                    onClick = {
-                                        // pendiente la creacion de un album.
-                                    }
-                            ) {
+                            IconButton(onClick = { navController.navigate("albumes/create") }) {
                                 Icon(
                                         imageVector = Icons.Rounded.AddCircle,
                                         contentDescription = "Agregar álbum",

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/CreateAlbumScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/CreateAlbumScreen.kt
@@ -1,0 +1,482 @@
+package com.uniandes.vinilosapp.views.album
+
+import android.app.Application
+import android.app.DatePickerDialog
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBackIos
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import com.uniandes.vinilosapp.models.GENRE
+import com.uniandes.vinilosapp.viewmodels.CreateAlbumViewModel
+import java.util.Calendar
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateAlbumScreen(navController: NavController) {
+    val application = LocalContext.current.applicationContext as Application
+    val context = LocalContext.current
+
+    val viewModel: CreateAlbumViewModel =
+            viewModel(factory = CreateAlbumViewModel.Factory(application))
+
+    // Define a more rounded corner shape for all input fields
+    val inputShape = RoundedCornerShape(16.dp)
+
+    // Observe view model state
+    val name by viewModel.name.observeAsState("")
+    val description by viewModel.description.observeAsState("")
+    val coverUrl by viewModel.coverUrl.observeAsState("")
+    val isValidUrl by viewModel.isValidUrl.observeAsState(false)
+    val genre by viewModel.genre.observeAsState()
+    val recordLabel by viewModel.recordLabel.observeAsState()
+    val isLoading by viewModel.isLoading.observeAsState(false)
+    val error by viewModel.error.observeAsState()
+    val createSuccess by viewModel.createSuccess.observeAsState(false)
+    val isFormValid by viewModel.isFormValid.observeAsState(false)
+
+    // Release date state
+    val dateFormatted by viewModel.releaseDateFormatted.observeAsState("Seleccionar fecha")
+
+    // Touch states
+    val nameTouched by viewModel.nameTouched.observeAsState(false)
+    val descriptionTouched by viewModel.descriptionTouched.observeAsState(false)
+    val coverUrlTouched by viewModel.coverUrlTouched.observeAsState(false)
+    val genreTouched by viewModel.genreTouched.observeAsState(false)
+    val recordLabelTouched by viewModel.recordLabelTouched.observeAsState(false)
+    val releaseDateTouched by viewModel.releaseDateTouched.observeAsState(false)
+
+    // Validation error states
+    val nameError by viewModel.nameError.observeAsState()
+    val descriptionError by viewModel.descriptionError.observeAsState()
+    val coverUrlError by viewModel.coverUrlError.observeAsState()
+    val genreError by viewModel.genreError.observeAsState()
+    val recordLabelError by viewModel.recordLabelError.observeAsState()
+    val releaseDateError by viewModel.releaseDateError.observeAsState()
+
+    // Dropdown state
+    var genreExpanded by remember { mutableStateOf(false) }
+    var recordLabelExpanded by remember { mutableStateOf(false) }
+
+    // Setup date picker
+    val calendar = Calendar.getInstance()
+    val datePickerDialog =
+            DatePickerDialog(
+                    context,
+                    { _, year, month, dayOfMonth ->
+                        calendar.set(year, month, dayOfMonth)
+                        viewModel.updateReleaseDate(calendar.time)
+                    },
+                    calendar.get(Calendar.YEAR),
+                    calendar.get(Calendar.MONTH),
+                    calendar.get(Calendar.DAY_OF_MONTH)
+            )
+
+    // Set max date to today to restrict future dates
+    datePickerDialog.datePicker.maxDate = Calendar.getInstance().timeInMillis
+
+    // Handle success or error
+    LaunchedEffect(createSuccess, error) {
+        if (createSuccess) {
+            Toast.makeText(context, "Álbum creado exitosamente", Toast.LENGTH_SHORT).show()
+            navController.navigateUp()
+        }
+
+        error?.let { errorMsg ->
+            Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
+            viewModel.resetState()
+        }
+    }
+
+    Scaffold(
+            topBar = {
+                TopAppBar(
+                        title = { Text("Crear Album", fontWeight = FontWeight.Bold) },
+                        navigationIcon = {
+                            IconButton(onClick = { navController.popBackStack() }) {
+                                Icon(
+                                        imageVector = Icons.AutoMirrored.Filled.ArrowBackIos,
+                                        contentDescription = "Go back",
+                                )
+                            }
+                        }
+                )
+            }
+    ) { innerPadding ->
+        if (isLoading) {
+            Box(
+                    modifier = Modifier.fillMaxSize().padding(innerPadding),
+                    contentAlignment = Alignment.Center
+            ) { CircularProgressIndicator() }
+        } else {
+            Column(
+                    modifier =
+                            Modifier.fillMaxSize()
+                                    .padding(innerPadding)
+                                    .padding(horizontal = 16.dp)
+                                    .verticalScroll(rememberScrollState())
+            ) {
+                // Image placeholder
+                Box(
+                        modifier =
+                                Modifier.fillMaxWidth()
+                                        .height(200.dp)
+                                        .padding(vertical = 16.dp)
+                                        .clip(inputShape)
+                                        .background(Color.LightGray.copy(alpha = 0.3f))
+                                        .border(
+                                                width = 1.dp,
+                                                color =
+                                                        if (coverUrlTouched && coverUrlError != null
+                                                        )
+                                                                Color.Red
+                                                        else Color.LightGray,
+                                                shape = inputShape
+                                        ),
+                        contentAlignment = Alignment.Center
+                ) {
+                    if (isValidUrl) {
+                        AsyncImage(
+                                model =
+                                        ImageRequest.Builder(context)
+                                                .data(coverUrl)
+                                                .crossfade(true)
+                                                .build(),
+                                contentDescription = "Cover Image",
+                                modifier = Modifier.fillMaxSize().clip(inputShape)
+                        )
+                    } else {
+                        Text(
+                                text = "Vista previa de la imagen",
+                                color =
+                                        if (coverUrlTouched && coverUrlError != null) Color.Red
+                                        else Color.Gray
+                        )
+                    }
+                }
+
+                // Name field with rounded corners
+                OutlinedTextField(
+                        value = name,
+                        onValueChange = { viewModel.updateName(it) },
+                        label = { Text("Nombre") },
+                        isError = nameTouched && nameError != null,
+                        supportingText = {
+                            if (nameTouched && nameError != null) {
+                                Text(text = nameError!!, color = Color.Red)
+                            }
+                        },
+                        shape = inputShape,
+                        colors =
+                                OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = Color.Black,
+                                        focusedLabelColor = Color.Black,
+                                        unfocusedBorderColor = Color.Gray,
+                                        errorBorderColor = Color.Red,
+                                ),
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                )
+
+                // Description field with rounded corners
+                OutlinedTextField(
+                        value = description,
+                        onValueChange = { viewModel.updateDescription(it) },
+                        label = { Text("Descripción") },
+                        isError = descriptionTouched && descriptionError != null,
+                        supportingText = {
+                            if (descriptionTouched && descriptionError != null) {
+                                Text(text = descriptionError!!, color = Color.Red)
+                            }
+                        },
+                        shape = inputShape,
+                        colors =
+                                OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = Color.Black,
+                                        focusedLabelColor = Color.Black,
+                                        unfocusedBorderColor = Color.Gray,
+                                        errorBorderColor = Color.Red
+                                ),
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                )
+
+                // Cover URL field with rounded corners
+                OutlinedTextField(
+                        value = coverUrl,
+                        onValueChange = { viewModel.updateCoverUrl(it) },
+                        label = { Text("URL del Cover") },
+                        isError = coverUrlTouched && coverUrlError != null,
+                        supportingText = {
+                            if (coverUrlTouched && coverUrlError != null) {
+                                Text(text = coverUrlError!!, color = Color.Red)
+                            }
+                        },
+                        shape = inputShape,
+                        colors =
+                                OutlinedTextFieldDefaults.colors(
+                                        focusedBorderColor = Color.Black,
+                                        focusedLabelColor = Color.Black,
+                                        unfocusedBorderColor = Color.Gray,
+                                        errorBorderColor = Color.Red
+                                ),
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)
+                )
+
+                // Release Date field with date picker
+                Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                    OutlinedTextField(
+                            value = dateFormatted,
+                            onValueChange = { /* Read only field */},
+                            label = { Text("Fecha de lanzamiento") },
+                            readOnly = true,
+                            isError = releaseDateTouched && releaseDateError != null,
+                            supportingText = {
+                                if (releaseDateTouched && releaseDateError != null) {
+                                    Text(text = releaseDateError!!, color = Color.Red)
+                                }
+                            },
+                            shape = inputShape,
+                            colors =
+                                    OutlinedTextFieldDefaults.colors(
+                                            focusedBorderColor = Color.Black,
+                                            focusedLabelColor = Color.Black,
+                                            unfocusedBorderColor = Color.Gray,
+                                            errorBorderColor = Color.Red
+                                    ),
+                            trailingIcon = {
+                                Icon(
+                                        Icons.Default.CalendarMonth,
+                                        contentDescription = "Seleccionar fecha",
+                                        tint =
+                                                if (releaseDateTouched && releaseDateError != null)
+                                                        Color.Red
+                                                else Color.Gray
+                                )
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                    )
+
+                    // Transparent clickable overlay
+                    Box(
+                            modifier =
+                                    Modifier.matchParentSize().clickable(
+                                                    indication = null, // No ripple effect
+                                                    interactionSource =
+                                                            remember { MutableInteractionSource() }
+                                            ) {
+                                        viewModel.onReleaseDateTouched()
+                                        datePickerDialog.show()
+                                    }
+                    )
+                }
+
+                // Genre dropdown with rounded corners
+                Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                    OutlinedTextField(
+                            value = genre?.toString() ?: "Selecciona un género",
+                            onValueChange = {},
+                            label = { Text("Género") },
+                            readOnly = true,
+                            isError = genreTouched && genreError != null,
+                            supportingText = {
+                                if (genreTouched && genreError != null) {
+                                    Text(text = genreError!!, color = Color.Red)
+                                }
+                            },
+                            shape = inputShape,
+                            colors =
+                                    OutlinedTextFieldDefaults.colors(
+                                            focusedBorderColor = Color.Black,
+                                            focusedLabelColor = Color.Black,
+                                            unfocusedBorderColor = Color.Gray,
+                                            errorBorderColor = Color.Red
+                                    ),
+                            trailingIcon = {
+                                Icon(
+                                        Icons.Default.ArrowDropDown,
+                                        contentDescription = "Dropdown",
+                                        tint =
+                                                if (genreTouched && genreError != null) Color.Red
+                                                else Color.Gray
+                                )
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                    )
+
+                    // Transparent clickable overlay
+                    Box(
+                            modifier =
+                                    Modifier.matchParentSize().clickable(
+                                                    indication = null, // No ripple effect
+                                                    interactionSource =
+                                                            remember { MutableInteractionSource() }
+                                            ) {
+                                        genreExpanded = true
+                                        viewModel.onGenreTouched()
+                                    }
+                    )
+
+                    DropdownMenu(
+                            expanded = genreExpanded,
+                            onDismissRequest = { genreExpanded = false },
+                            modifier = Modifier.fillMaxWidth(0.9f)
+                    ) {
+                        GENRE.values().forEach { genreOption ->
+                            DropdownMenuItem(
+                                    text = { Text(genreOption.toString()) },
+                                    onClick = {
+                                        viewModel.updateGenre(genreOption)
+                                        genreExpanded = false
+                                    }
+                            )
+                        }
+                    }
+                }
+
+                // Record label dropdown with rounded corners
+                Box(modifier = Modifier.fillMaxWidth().padding(vertical = 8.dp)) {
+                    OutlinedTextField(
+                            value = recordLabel?.toString() ?: "Selecciona una disquera",
+                            onValueChange = {},
+                            label = { Text("Disquera") },
+                            readOnly = true,
+                            isError = recordLabelTouched && recordLabelError != null,
+                            supportingText = {
+                                if (recordLabelTouched && recordLabelError != null) {
+                                    Text(text = recordLabelError!!, color = Color.Red)
+                                }
+                            },
+                            shape = inputShape,
+                            colors =
+                                    OutlinedTextFieldDefaults.colors(
+                                            focusedBorderColor = Color.Black,
+                                            focusedLabelColor = Color.Black,
+                                            unfocusedBorderColor = Color.Gray,
+                                            errorBorderColor = Color.Red
+                                    ),
+                            trailingIcon = {
+                                Icon(
+                                        Icons.Default.ArrowDropDown,
+                                        contentDescription = "Dropdown",
+                                        tint =
+                                                if (recordLabelTouched && recordLabelError != null)
+                                                        Color.Red
+                                                else Color.Gray
+                                )
+                            },
+                            modifier = Modifier.fillMaxWidth()
+                    )
+
+                    // Transparent clickable overlay
+                    Box(
+                            modifier =
+                                    Modifier.matchParentSize().clickable(
+                                                    indication = null, // No ripple effect
+                                                    interactionSource =
+                                                            remember { MutableInteractionSource() }
+                                            ) {
+                                        recordLabelExpanded = true
+                                        viewModel.onRecordLabelTouched()
+                                    }
+                    )
+
+                    DropdownMenu(
+                            expanded = recordLabelExpanded,
+                            onDismissRequest = { recordLabelExpanded = false },
+                            modifier = Modifier.fillMaxWidth(0.9f)
+                    ) {
+                        com.uniandes.vinilosapp.models.RECORD_LABEL.values().forEach { labelOption
+                            ->
+                            DropdownMenuItem(
+                                    text = { Text(labelOption.toString()) },
+                                    onClick = {
+                                        viewModel.updateRecordLabel(labelOption)
+                                        recordLabelExpanded = false
+                                    }
+                            )
+                        }
+                    }
+                }
+
+                // Save button with rounded corners
+                Button(
+                        onClick = {
+                            // Mark all fields as touched when trying to save
+                            viewModel.onNameTouched()
+                            viewModel.onDescriptionTouched()
+                            viewModel.onCoverUrlTouched()
+                            viewModel.onGenreTouched()
+                            viewModel.onRecordLabelTouched()
+                            viewModel.onReleaseDateTouched()
+                            viewModel.createAlbum()
+                        },
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 16.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors =
+                                ButtonDefaults.buttonColors(
+                                        containerColor = Color.Black,
+                                        contentColor = Color.White,
+                                        disabledContainerColor = Color.Gray
+                                ),
+                        enabled = isFormValid
+                ) { Text("Guardar") }
+
+                // Cancel button with matching rounded corners
+                TextButton(
+                        onClick = { navController.navigateUp() },
+                        modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+                        shape = RoundedCornerShape(16.dp),
+                        colors =
+                                ButtonDefaults.buttonColors(
+                                        containerColor = Color.Transparent,
+                                        contentColor = Color.Black,
+                                ),
+                ) { Text("Cancelar") }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilosapp/views/album/CreateAlbumScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/album/CreateAlbumScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
@@ -124,12 +125,23 @@ fun CreateAlbumScreen(navController: NavController) {
     LaunchedEffect(createSuccess, error) {
         if (createSuccess) {
             Toast.makeText(context, "Álbum creado exitosamente", Toast.LENGTH_SHORT).show()
+            // Set a refresh flag in the backstack entry for AlbumsScreen to detect
+            navController.previousBackStackEntry?.savedStateHandle?.set("refresh_albums", true)
             navController.navigateUp()
         }
 
         error?.let { errorMsg ->
             Toast.makeText(context, errorMsg, Toast.LENGTH_LONG).show()
             viewModel.resetState()
+        }
+    }
+
+    // Ensure the refresh flag is set when we return to the AlbumsScreen
+    DisposableEffect(Unit) {
+        onDispose {
+            if (createSuccess) {
+                navController.previousBackStackEntry?.savedStateHandle?.set("refresh_albums", true)
+            }
         }
     }
 

--- a/app/src/main/java/com/uniandes/vinilosapp/views/navigation/Navigation.kt
+++ b/app/src/main/java/com/uniandes/vinilosapp/views/navigation/Navigation.kt
@@ -14,6 +14,7 @@ import androidx.navigation.navArgument
 import com.uniandes.vinilosapp.models.PerformerType
 import com.uniandes.vinilosapp.views.album.AlbumDetailScreen
 import com.uniandes.vinilosapp.views.album.AlbumsScreen
+import com.uniandes.vinilosapp.views.album.CreateAlbumScreen
 import com.uniandes.vinilosapp.views.collector.CollectorScreen
 import com.uniandes.vinilosapp.views.performer.PerformerDetailScreen
 import com.uniandes.vinilosapp.views.performer.PerformerScreen
@@ -28,6 +29,7 @@ fun Navigation() {
     val shouldShowTabs =
             currentRoute != null &&
                     !currentRoute.startsWith("albumes/") &&
+                    !currentRoute.equals("crear-album") &&
                     !currentRoute.startsWith("performers/")
 
     Scaffold(
@@ -44,6 +46,7 @@ fun Navigation() {
         ) {
             // Album routes
             composable("albumes") { AlbumsScreen(navController = navController) }
+            composable("albumes/create") { CreateAlbumScreen(navController = navController) }
             composable(
                     route = "albumes/{albumId}",
                     arguments = listOf(navArgument("albumId") { type = NavType.IntType })


### PR DESCRIPTION
## BITÁCORA DE DESARROLLO

- Se implementaron convertidores de tipo para los enums GENRE y RECORD_LABEL en el modelo Album.

- Se añadió la pantalla CreateAlbumScreen y se integró con la navegación existente.

- Se mejoró la gestión de álbumes con funcionalidad de actualización y verificación de conexión de red.

- Se actualizó la configuración de la base de datos para incluir los nuevos convertidores y se realizaron ajustes en las consultas DAO.

- Se elimina local cache al crear un nuevo album permitiendo mostrar el listado actualizado de albums al retornar a esta vista después de crear un nuevo album.

- Se añadió un loading state a la vista de listar albums

https://github.com/user-attachments/assets/86cfe5ab-5374-40f0-97ae-bc1b4a245ffa


